### PR TITLE
Fix links to the .glyphs files

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -2,8 +2,8 @@
 
 There are 2 source files, one for Romans and one of Italics, in the [GlyphsApp](https://www.glyphsapp.com/) format:
 
-* [../sources/Merriweather.glyphs](../master/sources/Merriweather.glyphs)
-* [../sources/Merriweather-Italic.glyphs](../master/sources/Merriweather-Italic.glyphs)
+* [sources/Merriweather.glyphs](../sources/Merriweather.glyphs)
+* [sources/Merriweather-Italic.glyphs](../sources/Merriweather-Italic.glyphs)
 
 GlyphsApp is required for generating font files from these sources. At the moment there is no headless version of GlyphsApp to export fonts using a script shell. Stay tuned to this [thread](https://forum.glyphsapp.com/t/how-to-automate-glyphs-export/4800/11) for updates.
 


### PR DESCRIPTION
They linked to `https://github.com/EbenSorkin/Merriweather/blob/master/master/sources/Merriweather.glyphs` previously.